### PR TITLE
Revert to simple SPA config

### DIFF
--- a/app/image-tools/vercel.json
+++ b/app/image-tools/vercel.json
@@ -1,6 +1,6 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [
-    { "source": "/api/(.*)", "destination": "/api/$1" },
     { "source": "/(.*)", "destination": "/" }
   ]
 }


### PR DESCRIPTION
SPA was configured correctly. We need to change the name of /app/image-tools/server to /api so vercel knows to use that as the api by convention

Please review the following token assets:

## 📑 Description

<!-- Some basic information about the token you want to add -->

-   Token Name: ...
-   Project Website: https://... <!-- ⚠️ Your website MUST contain of the token address or the PR will be rejected -->
-   Explorer URI: https://...

---

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

-   [ ] I created a new folder with the token address (**all in lowercase** for EVM chains, **case sensitive** for Solana)
-   [ ] I added the token's logo as a `32x32` PNG file, named `logo-32.png`
-   [ ] I added the token's logo as a `128x128` PNG file, named `logo-128.png`
-   [ ] I added the token's logo as a SVG file, named `logo.svg`
-   [ ] My SVG logo is a proper SVG and does not contain base64 encoded elements
-   [ ] My documentation/website clearly display the token address
