### PR TITLE
Pin token asset push action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         #    enforce_admins: false
 
         - name: Push changes
-          uses: ad-m/github-push-action@master
+          uses: ad-m/github-push-action@d30dc2d070765d7e509df00c34c5fa2dd636ff74
           with:
             github_token: ${{ secrets.ACCESS_TOKEN }}
             branch: ${{ github.ref }}


### PR DESCRIPTION
Pin the token asset publishing action to an immutable commit.

Notes:
- Replaces `ad-m/github-push-action@master` in the workflow path that uses a repository access token.
- Reduces supply-chain exposure from upstream branch movement.
- Validated touched workflows with PyYAML and git diff --check.

Please review the following token assets:

## 📑 Description

<!-- Some basic information about the token you want to add -->

-   Token Name: ...
-   Project Website: https://... <!-- ⚠️ Your website MUST contain of the token address or the PR will be rejected -->
-   Explorer URI: https://...

---

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

-   [ ] I created a new folder with the token address (**all in lowercase** for EVM chains, **case sensitive** for Solana)
-   [ ] I added the token's logo as a `32x32` PNG file, named `logo-32.png`
-   [ ] I added the token's logo as a `128x128` PNG file, named `logo-128.png`
-   [ ] I added the token's logo as a SVG file, named `logo.svg`
-   [ ] My SVG logo is a proper SVG and does not contain base64 encoded elements
-   [ ] My documentation/website clearly display the token address
