### PR TITLE
fix: avoid OAuth redirect URI warning

### DIFF
--- a/app/image-tools/README.md
+++ b/app/image-tools/README.md
@@ -13,8 +13,12 @@ A lightweight SPA + Vercel Functions app for uploading token/chain assets and op
     -   `APP_BASE_URL` — optional; default request origin. Only set if SPA and API are on different origins. For the
         public deployment, leave unset or set to `https://token-assets.yearn.fi`; do not point this at a Vercel alias.
     -   `REPO_OWNER` (default `yearn`), `REPO_NAME` (default `tokenAssets`).
-    -   `ALLOW_REPO_OVERRIDE` — set to `true` only if you intentionally want to target a non-yearn repo when deploying from a fork.
--   GitHub OAuth App callback must allow the current domain: `https://<domain>/api/auth/github/callback` (or `http://localhost:3000/...` for `vercel dev`).
+    -   `ALLOW_REPO_OVERRIDE` — set to `true` only if you intentionally want to target a non-yearn repo when deploying
+        from a fork.
+-   GitHub OAuth App callback must be configured to the deployed API callback URL:
+    `https://<api-domain>/api/auth/github/callback`. The client intentionally does not send a `redirect_uri`; GitHub
+    uses the callback URL registered on the OAuth App, and the API redirects back to `APP_BASE_URL` after exchanging the
+    code.
 
 ## Commands
 

--- a/app/image-tools/api/auth/github/callback.ts
+++ b/app/image-tools/api/auth/github/callback.ts
@@ -5,7 +5,6 @@ export default async function (req: Request): Promise<Response> {
 		const url = new URL(req.url);
 		const code = url.searchParams.get('code');
 		const state = url.searchParams.get('state') || '';
-		const redirectUri = new URL('/api/auth/github/callback', url.origin).toString();
 		if (!code) {
 			return new Response(JSON.stringify({error: 'Missing code'}), {
 				status: 400,
@@ -28,8 +27,7 @@ export default async function (req: Request): Promise<Response> {
 			body: JSON.stringify({
 				client_id: clientId,
 				client_secret: clientSecret,
-				code,
-				redirect_uri: redirectUri
+				code
 			})
 		});
 		if (!tokenRes.ok) {

--- a/app/image-tools/src/components/GithubSignIn.tsx
+++ b/app/image-tools/src/components/GithubSignIn.tsx
@@ -6,12 +6,10 @@ import {
 	storeAuthState,
 	clearStoredAuth,
 	buildAuthorizeUrl,
-	getGithubCallbackUrl,
 	markAuthPending,
 	clearAuthPending,
 	readAuthPending
 } from '../lib/githubAuth';
-import {API_BASE_URL} from '../lib/api';
 
 function randomState(len = 20) {
 	const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
@@ -67,7 +65,7 @@ export const GithubSignIn: React.FC<Props> = ({token}) => {
 		storeAuthState(state);
 		markAuthPending();
 		setConnecting(true);
-		window.location.href = buildAuthorizeUrl(clientId, state, getGithubCallbackUrl(API_BASE_URL));
+		window.location.href = buildAuthorizeUrl(clientId, state);
 	};
 
 	const signOut = () => {

--- a/app/image-tools/src/lib/githubAuth.ts
+++ b/app/image-tools/src/lib/githubAuth.ts
@@ -3,16 +3,11 @@ export const AUTH_STATE_STORAGE_KEY = 'auth_state';
 export const AUTH_CHANGE_EVENT = 'github-auth-changed';
 export const AUTH_PENDING_STORAGE_KEY = 'github_oauth_pending';
 
-export function getGithubCallbackUrl(origin = window.location.origin) {
-	return new URL('/api/auth/github/callback', origin).toString();
-}
-
-export function buildAuthorizeUrl(clientId: string, state: string, redirectUri = getGithubCallbackUrl()) {
+export function buildAuthorizeUrl(clientId: string, state: string) {
 	const url = new URL('https://github.com/login/oauth/authorize');
 	url.searchParams.set('client_id', clientId);
 	url.searchParams.set('state', state);
 	url.searchParams.set('scope', 'public_repo');
-	url.searchParams.set('redirect_uri', redirectUri);
 	url.searchParams.set('prompt', 'select_account');
 	return url.toString();
 }


### PR DESCRIPTION
## Summary

Fixes the GitHub OAuth warning shown during sign-in:

> Be careful! The `redirect_uri` is not associated with this application.

The warning appeared after the previous OAuth change started sending an explicit `redirect_uri` from the browser. That value was derived from the runtime/API origin, so GitHub required every deployed domain or preview URL to be registered on the OAuth App. When the current host was not registered, GitHub showed the warning before login.

## Fix

- Stop sending `redirect_uri` in the browser authorize URL.
- Stop sending `redirect_uri` during the token exchange.
- Let GitHub use the OAuth App's registered callback URL.
- Keep `APP_BASE_URL` responsible for redirecting from the API callback back to the SPA.
- Update the image-tools README to document the callback configuration.

## Validation

- `bun run typecheck`
- `bun run build`
